### PR TITLE
[MAJOR-PR] Production DB & Sample DB Separation + Makefile Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,0 @@
-POSTGRES_USER=cs348
-POSTGRES_PASSWORD=group10
-POSTGRES_DB=housing_db
-DATABASE_URL=postgresql://cs348:group10@localhost:5432/housing_db

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,7 @@
+DB_ENV=production
+
+# Production
+POSTGRES_USER=cs348
+POSTGRES_PASSWORD=group10
+POSTGRES_DB=housing_db
+DATABASE_URL=postgresql://cs348:group10@db:5432/housing_db

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,13 @@
+DB_ENV=sample
+
+# Production (for Client)
+POSTGRES_USER=cs348
+POSTGRES_PASSWORD=group10
+POSTGRES_DB=housing_db
+DATABASE_URL=postgresql://cs348:group10@db:5432/housing_db
+
+# Sample
+SAMPLE_POSTGRES_USER=cs348-sample
+SAMPLE_POSTGRES_PASSWORD=group10-sample
+SAMPLE_POSTGRES_DB=sample_housing_db
+SAMPLE_DATABASE_URL=postgresql://cs348-sample:group10-sample@db-sample:5432/sample_housing_db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+# Instead of 'docker-compose up --build', you may use
+#	make run-sample 	to use sample DB
+# 	make run-prod		to use production DB
+#
+# Client (Frontend) will use production DB only in any case
+
+run-sample:
+	DB_ENV=sample docker compose -f docker-compose.yml -f docker-compose.sample.yml --env-file .env.sample up --build
+
+run-prod:
+	DB_ENV=production docker compose -f docker-compose.yml -f docker-compose.production.yml --env-file .env.production up --build
+
+clean-sample:
+	docker compose -f docker-compose.yml -f docker-compose.sample.yml down --volumes --remove-orphans
+
+clean-prod:
+	docker compose -f docker-compose.yml -f docker-compose.production.yml down --volumes --remove-orphans
+
+clean-default:
+	docker compose down --volumes --remove-orphans
+
+clean-all:
+	docker compose -f docker-compose.yml -f docker-compose.sample.yml down --volumes --remove-orphans 2>/dev/null || true
+	docker compose -f docker-compose.yml -f docker-compose.production.yml down --volumes --remove-orphans 2>/dev/null || true
+	docker compose down --volumes --remove-orphans 2>/dev/null || true
+
+run-sample-sql:
+	DB_ENV=sample docker compose -f docker-compose.yml -f docker-compose.sample.yml --env-file .env.sample up -d --build
+	docker compose exec backend python app/seed_data.py
+	docker compose exec -T db-sample psql -U cs348-sample -d sample_housing_db < test-sample.sql > test-sample.out
+	cat test-sample.out

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,3 @@
+from .base import Base
+from .db_prod import SessionLocal, engine
+from .db_sample import SessionLocal, engine

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()

--- a/backend/app/db/db_prod.py
+++ b/backend/app/db/db_prod.py
@@ -1,14 +1,21 @@
-from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 import os
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://cs348:group10@localhost:5432/housing_db")
+# production
+DB_ENV = os.getenv("DB_ENV")
 
+def get_prod_db_url():
+    print(f"""
+Run Production Database
+Current Env: {DB_ENV}
+    """)
+    return os.getenv("DATABASE_URL")
+
+DATABASE_URL = get_prod_db_url()
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-Base = declarative_base()
 
 def get_db():
     db = SessionLocal()
@@ -16,3 +23,4 @@ def get_db():
         yield db
     finally:
         db.close()
+

--- a/backend/app/db/db_sample.py
+++ b/backend/app/db/db_sample.py
@@ -1,0 +1,25 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import os
+
+# production
+DB_ENV = os.getenv("DB_ENV")
+
+def get_sample_database_url():
+    sample_db_url = os.getenv("SAMPLE_DATABASE_URL")
+    if not sample_db_url:
+        raise ValueError(f"""
+There is no SAMPLE_DATABASE_URL
+                             
+Current Env: {DB_ENV}
+If current environment is production, please run 'make run-sample'
+        """)
+    print(f"""
+Run Sample Database
+Current Env: {DB_ENV}
+    """)
+    return sample_db_url 
+
+DATABASE_URL = get_sample_database_url()
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/app/import_data.py
+++ b/backend/app/import_data.py
@@ -1,7 +1,8 @@
 import pandas as pd
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
-from app.database import SessionLocal, engine, Base
+from app.db.db_prod import SessionLocal, engine
+from app.db.base import Base
 from app.models import Region, Property, HousingPrice, IncomeData
 import random
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,8 @@ from sqlalchemy import func, text, create_engine
 
 import app.models
 from app.models import Apartment, Property, HousingPrice, Region, IncomeData
-from app.database import SessionLocal, engine, Base
+from app.db.db_prod import SessionLocal, engine
+from app.db.base import Base
 from app.import_data import full_reset, load_csv_data, verify_data
 
 app = FastAPI()

--- a/backend/app/models/apartments_model.py
+++ b/backend/app/models/apartments_model.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, Float, ForeignKey
-from app.database import Base
+from app.db.base import Base
 
 class Apartment(Base):
     __tablename__ = "apartments"

--- a/backend/app/models/housing_price_model.py
+++ b/backend/app/models/housing_price_model.py
@@ -5,7 +5,7 @@ HousingPrice(housing_id Int, property_id Int, year Int, avg_price Float)
 '''
 
 from sqlalchemy import Column, Integer, Float, ForeignKey, UniqueConstraint
-from app.database import Base
+from app.db.base import Base
 
 class HousingPrice(Base):
     __tablename__ = "housing_price"

--- a/backend/app/models/income_data.py
+++ b/backend/app/models/income_data.py
@@ -5,7 +5,7 @@ IncomeData(income_id Int, region_id Int, year Int, avg_income Float)
 """
 
 from sqlalchemy import Column, Integer, Float, ForeignKey, UniqueConstraint
-from app.database import Base
+from app.db.base import Base
 
 class IncomeData(Base):
     __tablename__ = "income_data"

--- a/backend/app/models/property_model.py
+++ b/backend/app/models/property_model.py
@@ -5,7 +5,7 @@ Property(property_id Int, region_id Int, type String, subtype String)
 '''
 
 from sqlalchemy import Column, Integer, String, Float, ForeignKey
-from app.database import Base
+from app.db.base import Base
 
 # Property(property_id, region_id, type, subtype) (Minjae Lee)
 

--- a/backend/app/models/region_model.py
+++ b/backend/app/models/region_model.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String
-from app.database import Base
+from app.db.base import Base
 
 class Region(Base):
     __tablename__ = "region"

--- a/backend/app/seed_data.py
+++ b/backend/app/seed_data.py
@@ -3,7 +3,8 @@ Author: Nandini Mehrotra
 Purpose: Drop & recreate tables, then insert dummy data for Region, Property, HousingPrice and IncomeData.
 """
 
-from app.database import SessionLocal, engine, Base
+from app.db.db_sample import SessionLocal, engine
+from app.db.base import Base
 from app.models import Region, Property, HousingPrice, IncomeData
 
 def seed():

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+
+services:
+  backend:
+    environment:
+      - DATABASE_URL=postgresql://cs348:group10@db:5432/housing_db
+      - DB_ENV=productionoad

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -1,0 +1,36 @@
+# override for sample db
+
+version: '3.8'
+
+services:
+  backend:
+    depends_on:
+      db:
+        condition: service_healthy
+      db-sample:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgresql://cs348:group10@db:5432/housing_db
+      - SAMPLE_DATABASE_URL=postgresql://cs348-sample:group10-sample@db-sample:5432/sample_housing_db
+      - DB_ENV=sample
+
+  db-sample:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: sample_housing_db
+      POSTGRES_USER: cs348-sample
+      POSTGRES_PASSWORD: group10-sample
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_sample_data:/var/lib/postgresql/data
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cs348-sample -d sample_housing_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_sample_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      - DATABASE_URL=postgresql://housing_user:housing_password@db:5432/housing_db
+      - DATABASE_URL=postgresql://cs348:group10@db:5432/housing_db
     volumes:
       - ./dataset:/app/dataset
     networks:
@@ -39,8 +39,8 @@ services:
     image: postgres:17
     environment:
       POSTGRES_DB: housing_db
-      POSTGRES_USER: housing_user
-      POSTGRES_PASSWORD: housing_password
+      POSTGRES_USER: cs348
+      POSTGRES_PASSWORD: group10
     ports:
       - "5432:5432"
     volumes:
@@ -48,7 +48,7 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U housing_user -d housing_db"]
+      test: ["CMD-SHELL", "pg_isready -U cs348 -d housing_db"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
**Outcomes**
1. Database Separation
- production: used by the frontend (client) and for actual deployments
- sample: used for local development and testing
2. Makefile for Docker Control

**Use Case for database separation**
To run sample database for your python file, you may need to use:
`from app.db.db_sample import SessionLocal, engine`
`from app.db.base import Base`

To run production database for your python file, you may need to use:
`from app.db.db_prod import SessionLocal, engine`
`from app.db.base import Base`


**Use Case for Makefile**
You need to run Docker or run sample sql through Makefile instead of 'docker-compose --build'

`make run-sample`: starts the sample + production database environment
`make run-prod`: starts the production database environment only
`make run-smaple-sql`: runs sample sql on the sample db env
`make clean-*`: You may need to run cleaner first after PR merged. This will clean Docker volumes and containers.