### PR TITLE
feat: adding frontend pages (with dummy data) for the features

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/material": "^7.2.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -2352,6 +2355,152 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
@@ -2964,6 +3113,216 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.2.0.tgz",
+      "integrity": "sha512-d49s7kEgI5iX40xb2YPazANvo7Bx0BLg/MNRwv+7BVpZUzXj1DaVCKlQTDex3gy/0jsCb4w7AY2uH4t4AJvSog==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.2.0.tgz",
+      "integrity": "sha512-NTuyFNen5Z2QY+I242MDZzXnFIVIR6ERxo7vntFi9K1wCgSwvIl0HcAO2OOydKqqKApE6omRiYhpny1ZhGuH7Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/core-downloads-tracker": "^7.2.0",
+        "@mui/system": "^7.2.0",
+        "@mui/types": "^7.4.4",
+        "@mui/utils": "^7.2.0",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.1.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^7.2.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.2.0.tgz",
+      "integrity": "sha512-y6N1Yt3T5RMxVFnCh6+zeSWBuQdNDm5/UlM0EAYZzZR/1u+XKJWYQmbpx4e+F+1EpkYi3Nk8KhPiQDi83M3zIw==",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/utils": "^7.2.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.2.0.tgz",
+      "integrity": "sha512-yq08xynbrNYcB1nBcW9Fn8/h/iniM3ewRguGJXPIAbHvxEF7Pz95kbEEOAAhwzxMX4okhzvHmk0DFuC5ayvgIQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.2.0.tgz",
+      "integrity": "sha512-PG7cm/WluU6RAs+gNND2R9vDwNh+ERWxPkqTaiXQJGIFAyJ+VxhyKfzpdZNk0z0XdmBxxi9KhFOpgxjehf/O0A==",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/private-theming": "^7.2.0",
+        "@mui/styled-engine": "^7.2.0",
+        "@mui/types": "^7.4.4",
+        "@mui/utils": "^7.2.0",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-p63yhbX52MO/ajXC7hDHJA5yjzJekvWD3q4YDLl1rSg+OXLczMYPvTuSuviPRCgRX8+E42RXz1D/dz9SxPSlWg==",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.2.0.tgz",
+      "integrity": "sha512-O0i1GQL6MDzhKdy9iAu5Yr0Sz1wZjROH1o3aoztuivdCXqEeQYnEjTDiRLGuFxI9zrUbTHBwobMyQH5sNtyacw==",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/types": "^7.4.4",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3086,6 +3445,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@remix-run/router": {
@@ -3822,6 +4190,11 @@
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
+    },
     "node_modules/@types/q": {
       "version": "1.5.8",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.8.tgz",
@@ -3839,6 +4212,23 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -5644,6 +6034,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6374,6 +6772,11 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "license": "MIT"
     },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6698,6 +7101,15 @@
       "license": "MIT",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -8171,6 +8583,11 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -8855,6 +9272,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -14049,6 +14479,21 @@
         }
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -15631,6 +16076,11 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/sucrase": {
       "version": "3.35.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "^7.2.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,11 @@ import React from "react";
 import { Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import Home from "./pages/Home";
+import HousingTrendsPage from "./pages/HousingTrendsPage";
+import IncomeTrendsPage from "./pages/IncomeTrendsPage";
+import WhereCanLivePage from "./pages/WhereCanLivePage";
+import ReverseLookupPage from "./pages/ReverseLookupPage";
+import AffordabilityRankingPage from "./pages/AffordabilityRankingPage";
 
 function App() {
   return (
@@ -9,6 +14,11 @@ function App() {
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/housing" element={<HousingTrendsPage />} />
+        <Route path="/income" element={<IncomeTrendsPage />} />
+        <Route path="/quiz" element={<WhereCanLivePage />} />
+        <Route path="/reverse-lookup" element={<ReverseLookupPage />} />
+        <Route path="/ranking" element={<AffordabilityRankingPage />} />
         {/* Add more routes like /quiz or /ranking later */}
       </Routes>
     </div>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -11,8 +11,8 @@ const Navbar = () => {
         <Link to="/">Home</Link>
         <Link to="/housing">Search Historical Housing</Link>
         <Link to="/income">Search Historical Income</Link>
-        <Link to="/ranking">Ranking</Link>
-        <Link to="/about">About</Link>
+        <Link to="/reverse-lookup">Reverse Lookup</Link>
+        <Link to="/ranking">Affordability Ranking</Link>
       </nav>
 
       <Link to="/quiz">

--- a/frontend/src/pages/AffordabilityRankingPage.js
+++ b/frontend/src/pages/AffordabilityRankingPage.js
@@ -1,0 +1,157 @@
+import React, { useState } from "react";
+import {
+  Container,
+  Typography,
+  Paper,
+  Stack,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  CircularProgress,
+  Box,
+} from "@mui/material";
+
+const YEARS = Array.from({ length: 21 }, (_, i) => 2000 + i);
+const PROPERTY_TYPES = ["House", "Condo", "Apartment"];
+
+// Dummy top‐5 ranking
+const DUMMY_RANKING = [
+  { region_id: 5, name: "Montreal", hai_index: 21.9 },
+  { region_id: 1, name: "Vancouver", hai_index: 21.82 },
+  { region_id: 4, name: "Ottawa", hai_index: 21.0 },
+  { region_id: 2, name: "Calgary", hai_index: 20.0 },
+  { region_id: 3, name: "Toronto", hai_index: 19.2 },
+];
+
+export default function AffordabilityRankingPage() {
+  const [year, setYear] = useState("");
+  const [propertyType, setPropertyType] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState([]);
+
+  const handleSearch = () => {
+    setLoading(true);
+    setResults([]);
+    // stub: immediately show dummy ranking
+    setTimeout(() => {
+      setResults(DUMMY_RANKING);
+      setLoading(false);
+    }, 500);
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ pt: 4, pb: 4 }}>
+      <Typography variant="h4" gutterBottom align="left">
+        Affordability Ranking by Region
+      </Typography>
+      <Typography
+        variant="subtitle1"
+        color="text.secondary"
+        gutterBottom
+        align="left"
+      >
+        Select a year and property type to see the top 5 most affordable regions
+        (HAI).
+      </Typography>
+
+      <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          alignItems="center"
+          flexWrap="wrap"
+        >
+          <FormControl size="small" sx={{ flex: "1 1 150px" }}>
+            <InputLabel>Year</InputLabel>
+            <Select
+              value={year}
+              label="Year"
+              onChange={(e) => setYear(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {YEARS.map((y) => (
+                <MenuItem key={y} value={y}>
+                  {y}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ flex: "1 1 180px" }}>
+            <InputLabel>Property Type</InputLabel>
+            <Select
+              value={propertyType}
+              label="Property Type"
+              onChange={(e) => setPropertyType(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {PROPERTY_TYPES.map((pt) => (
+                <MenuItem key={pt} value={pt}>
+                  {pt}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Button
+            variant="contained"
+            onClick={handleSearch}
+            disabled={loading}
+            sx={{ flex: "0 0 140px", height: 40 }}
+          >
+            {loading ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : (
+              "Search"
+            )}
+          </Button>
+        </Stack>
+      </Paper>
+
+      {results.length > 0 && !loading && (
+        <Paper elevation={1}>
+          <TableContainer sx={{ maxHeight: 350 }}>
+            <Table stickyHeader size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Region ID</TableCell>
+                  <TableCell>Name</TableCell>
+                  <TableCell align="right">HAI Index</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {results.map((row, idx) => (
+                  <TableRow key={idx} hover>
+                    <TableCell>{row.region_id}</TableCell>
+                    <TableCell>{row.name}</TableCell>
+                    <TableCell align="right">
+                      {row.hai_index.toFixed(2)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      )}
+
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress size={32} />
+        </Box>
+      )}
+    </Container>
+  );
+}

--- a/frontend/src/pages/HousingTrendsPage.css
+++ b/frontend/src/pages/HousingTrendsPage.css
@@ -1,0 +1,1 @@
+/* Optional custom overrides for MUI page */

--- a/frontend/src/pages/HousingTrendsPage.js
+++ b/frontend/src/pages/HousingTrendsPage.js
@@ -1,0 +1,238 @@
+import React, { useState, useEffect } from "react";
+import "./HousingTrendsPage.css";
+import {
+  Container,
+  Typography,
+  Paper,
+  Stack,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+  CircularProgress,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Box,
+} from "@mui/material";
+
+const PROVINCES = [
+  { code: "ON", name: "Ontario" },
+  { code: "QC", name: "Quebec" },
+  { code: "BC", name: "British Columbia" },
+];
+
+const REGIONS = {
+  ON: ["Toronto", "Ottawa"],
+  QC: ["Montreal", "Quebec City"],
+  BC: ["Vancouver", "Victoria"],
+};
+
+const PROPERTY_TYPES = ["House", "Condo", "Apartment"];
+
+export default function HousingTrendsPage() {
+  const [province, setProvince] = useState("");
+  const [region, setRegion] = useState("");
+  const [year, setYear] = useState("");
+  const [propertyType, setPropertyType] = useState("");
+  const [regions, setRegions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    if (province) setRegions(REGIONS[province] || []);
+    else {
+      setRegions([]);
+      setRegion("");
+    }
+  }, [province]);
+
+  const handleSearch = () => {
+    setSearched(true);
+    setLoading(true);
+
+    // stubbed data
+    setTimeout(() => {
+      const results = Array.from({ length: 6 }).map(() => {
+        const prov = PROVINCES[Math.floor(Math.random() * PROVINCES.length)];
+        const regs = REGIONS[prov.code];
+        const reg = regs[Math.floor(Math.random() * regs.length)];
+        const yr = 2000 + Math.floor(Math.random() * 21);
+        const pt =
+          PROPERTY_TYPES[Math.floor(Math.random() * PROPERTY_TYPES.length)];
+        const price =
+          Math.round((300000 + Math.random() * 1200000) / 1000) * 1000;
+        return {
+          region: reg,
+          province: prov.code,
+          year: yr,
+          property_type: pt,
+          avg_price: price,
+        };
+      });
+      setData(results);
+      setLoading(false);
+    }, 600);
+  };
+
+  return (
+    <Container maxWidth="lg" className="page-container" sx={{ pt: 4, pb: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Explore Historical Housing Prices
+      </Typography>
+      <Typography variant="subtitle1" color="text.secondary" gutterBottom>
+        View average home prices by region, year, and property type across
+        Canada.
+      </Typography>
+
+      <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          alignItems="center"
+          flexWrap="wrap"
+        >
+          <FormControl size="small" sx={{ flex: "1 1 200px" }}>
+            <InputLabel>Province</InputLabel>
+            <Select
+              value={province}
+              label="Province"
+              onChange={(e) => setProvince(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {PROVINCES.map((p) => (
+                <MenuItem key={p.code} value={p.code}>
+                  {p.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl
+            size="small"
+            sx={{ flex: "1 1 200px" }}
+            disabled={!province}
+          >
+            <InputLabel>Region</InputLabel>
+            <Select
+              value={region}
+              label="Region"
+              onChange={(e) => setRegion(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {regions.map((r) => (
+                <MenuItem key={r} value={r}>
+                  {r}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ flex: "1 1 150px" }}>
+            <InputLabel>Year</InputLabel>
+            <Select
+              value={year}
+              label="Year"
+              onChange={(e) => setYear(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {Array.from({ length: 21 }, (_, i) => 2000 + i).map((y) => (
+                <MenuItem key={y} value={y}>
+                  {y}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ flex: "1 1 180px" }}>
+            <InputLabel>Property Type</InputLabel>
+            <Select
+              value={propertyType}
+              label="Property Type"
+              onChange={(e) => setPropertyType(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {PROPERTY_TYPES.map((pt) => (
+                <MenuItem key={pt} value={pt}>
+                  {pt}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Button
+            variant="contained"
+            size="medium"
+            onClick={handleSearch}
+            disabled={loading}
+            sx={{ flex: "0 0 120px", height: 40 }}
+          >
+            {loading ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : (
+              "Search"
+            )}
+          </Button>
+        </Stack>
+      </Paper>
+
+      {searched && !loading && data.length === 0 && (
+        <Typography align="center" color="text.secondary">
+          No housing data found.
+        </Typography>
+      )}
+
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress size={32} />
+        </Box>
+      )}
+
+      {data.length > 0 && !loading && (
+        <TableContainer component={Paper} elevation={1}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Region</TableCell>
+                <TableCell>Province</TableCell>
+                <TableCell>Year</TableCell>
+                <TableCell>Property Type</TableCell>
+                <TableCell align="right">Average Price (CAD)</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.map((row, idx) => (
+                <TableRow key={idx} hover>
+                  <TableCell>{row.region}</TableCell>
+                  <TableCell>{row.province}</TableCell>
+                  <TableCell>{row.year}</TableCell>
+                  <TableCell>{row.property_type}</TableCell>
+                  <TableCell align="right">
+                    {new Intl.NumberFormat("en-CA", {
+                      style: "currency",
+                      currency: "CAD",
+                      maximumFractionDigits: 0,
+                    }).format(row.avg_price)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Container>
+  );
+}

--- a/frontend/src/pages/IncomeTrendsPage.css
+++ b/frontend/src/pages/IncomeTrendsPage.css
@@ -1,0 +1,1 @@
+/* Optional custom overrides for MUI page */

--- a/frontend/src/pages/IncomeTrendsPage.js
+++ b/frontend/src/pages/IncomeTrendsPage.js
@@ -1,0 +1,211 @@
+import React, { useState, useEffect } from "react";
+import "./IncomeTrendsPage.css";
+import {
+  Container,
+  Typography,
+  Paper,
+  Stack,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+  CircularProgress,
+  Box,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from "@mui/material";
+
+const PROVINCES = [
+  { code: "ON", name: "Ontario" },
+  { code: "QC", name: "Quebec" },
+  { code: "BC", name: "British Columbia" },
+];
+
+const REGIONS = {
+  ON: ["Toronto", "Ottawa"],
+  QC: ["Montreal", "Quebec City"],
+  BC: ["Vancouver", "Victoria"],
+};
+
+export default function IncomeTrendsPage() {
+  const [province, setProvince] = useState("");
+  const [region, setRegion] = useState("");
+  const [year, setYear] = useState("");
+  const [regions, setRegions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    if (province) setRegions(REGIONS[province] || []);
+    else {
+      setRegions([]);
+      setRegion("");
+    }
+  }, [province]);
+
+  const handleSearch = () => {
+    setSearched(true);
+    setLoading(true);
+
+    // stubbed data
+    setTimeout(() => {
+      const results = Array.from({ length: 6 }).map(() => {
+        const prov = PROVINCES[Math.floor(Math.random() * PROVINCES.length)];
+        const regs = REGIONS[prov.code];
+        const reg = regs[Math.floor(Math.random() * regs.length)];
+        const yr = 2000 + Math.floor(Math.random() * 21);
+        const income =
+          Math.round((50000 + Math.random() * 100000) / 1000) * 1000;
+        return {
+          region: reg,
+          province: prov.code,
+          year: yr,
+          avg_income: income,
+        };
+      });
+      setData(results);
+      setLoading(false);
+    }, 600);
+  };
+
+  return (
+    <Container maxWidth="lg" className="page-container" sx={{ pt: 4, pb: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Explore Historical Income
+      </Typography>
+      <Typography variant="subtitle1" color="text.secondary" gutterBottom>
+        View average incomes by region and year across Canada.
+      </Typography>
+
+      <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          alignItems="center"
+          flexWrap="wrap"
+        >
+          <FormControl size="small" sx={{ flex: "1 1 200px" }}>
+            <InputLabel>Province</InputLabel>
+            <Select
+              value={province}
+              label="Province"
+              onChange={(e) => setProvince(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {PROVINCES.map((p) => (
+                <MenuItem key={p.code} value={p.code}>
+                  {p.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl
+            size="small"
+            sx={{ flex: "1 1 200px" }}
+            disabled={!province}
+          >
+            <InputLabel>Region</InputLabel>
+            <Select
+              value={region}
+              label="Region"
+              onChange={(e) => setRegion(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {regions.map((r) => (
+                <MenuItem key={r} value={r}>
+                  {r}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ flex: "1 1 150px" }}>
+            <InputLabel>Year</InputLabel>
+            <Select
+              value={year}
+              label="Year"
+              onChange={(e) => setYear(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {Array.from({ length: 21 }, (_, i) => 2000 + i).map((y) => (
+                <MenuItem key={y} value={y}>
+                  {y}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Button
+            variant="contained"
+            size="medium"
+            onClick={handleSearch}
+            disabled={loading}
+            sx={{ flex: "0 0 120px", height: 40 }}
+          >
+            {loading ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : (
+              "Search"
+            )}
+          </Button>
+        </Stack>
+      </Paper>
+
+      {searched && !loading && data.length === 0 && (
+        <Typography align="center" color="text.secondary">
+          No income data found.
+        </Typography>
+      )}
+
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress size={32} />
+        </Box>
+      )}
+
+      {data.length > 0 && !loading && (
+        <TableContainer component={Paper} elevation={1}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Region</TableCell>
+                <TableCell>Province</TableCell>
+                <TableCell>Year</TableCell>
+                <TableCell align="right">Average Income (CAD)</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.map((row, idx) => (
+                <TableRow key={idx} hover>
+                  <TableCell>{row.region}</TableCell>
+                  <TableCell>{row.province}</TableCell>
+                  <TableCell>{row.year}</TableCell>
+                  <TableCell align="right">
+                    {new Intl.NumberFormat("en-CA", {
+                      style: "currency",
+                      currency: "CAD",
+                      maximumFractionDigits: 0,
+                    }).format(row.avg_income)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Container>
+  );
+}

--- a/frontend/src/pages/ReverseLookupPage.js
+++ b/frontend/src/pages/ReverseLookupPage.js
@@ -1,0 +1,168 @@
+import React, { useState } from "react";
+import {
+  Container,
+  Typography,
+  Paper,
+  Stack,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+  Button,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Box,
+  CircularProgress,
+} from "@mui/material";
+
+const YEARS = Array.from({ length: 21 }, (_, i) => 2000 + i);
+const PROPERTY_TYPES = ["House", "Condo", "Apartment"];
+
+// Dummy results
+const DUMMY_RESULTS = [
+  { region: "Toronto", property_type: "Condo", year: 2020, price: 625000 },
+  { region: "Vancouver", property_type: "House", year: 2019, price: 610000 },
+];
+
+export default function ReverseLookupPage() {
+  const [targetPrice, setTargetPrice] = useState("");
+  const [margin, setMargin] = useState(25000);
+  const [year, setYear] = useState("");
+  const [propertyType, setPropertyType] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState([]);
+
+  const handleSearch = () => {
+    setLoading(true);
+    // stub: show dummy results
+    setTimeout(() => {
+      setResults(DUMMY_RESULTS);
+      setLoading(false);
+    }, 500);
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ pt: 4, pb: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Where Did This Price Exist?
+      </Typography>
+      <Typography variant="subtitle1" color="text.secondary" gutterBottom>
+        Enter a price and optional filters to find regions within ±margin.
+      </Typography>
+
+      <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          alignItems="center"
+          flexWrap="wrap"
+        >
+          <FormControl size="small" sx={{ flex: "1 1 200px" }}>
+            <TextField
+              label="Target Price (CAD)"
+              type="number"
+              value={targetPrice}
+              onChange={(e) => setTargetPrice(e.target.value)}
+            />
+          </FormControl>
+
+          <FormControl size="small" sx={{ flex: "1 1 200px" }}>
+            <TextField
+              label="Margin (± CAD)"
+              type="number"
+              value={margin}
+              onChange={(e) => setMargin(e.target.value)}
+            />
+          </FormControl>
+
+          <FormControl size="small" sx={{ flex: "1 1 150px" }}>
+            <InputLabel>Year</InputLabel>
+            <Select
+              value={year}
+              label="Year"
+              onChange={(e) => setYear(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>Any</em>
+              </MenuItem>
+              {YEARS.map((y) => (
+                <MenuItem key={y} value={y}>
+                  {y}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ flex: "1 1 180px" }}>
+            <InputLabel>Property Type</InputLabel>
+            <Select
+              value={propertyType}
+              label="Property Type"
+              onChange={(e) => setPropertyType(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>Any</em>
+              </MenuItem>
+              {PROPERTY_TYPES.map((pt) => (
+                <MenuItem key={pt} value={pt}>
+                  {pt}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Button
+            variant="contained"
+            onClick={handleSearch}
+            disabled={loading}
+            sx={{ flex: "0 0 120px", height: 40 }}
+          >
+            {loading ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : (
+              "Search"
+            )}
+          </Button>
+        </Stack>
+      </Paper>
+
+      {results.length > 0 && (
+        <Paper elevation={1}>
+          <TableContainer sx={{ maxHeight: 300 }}>
+            <Table stickyHeader size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Region</TableCell>
+                  <TableCell>Property Type</TableCell>
+                  <TableCell>Year</TableCell>
+                  <TableCell align="right">Price (CAD)</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {results.map((row, i) => (
+                  <TableRow key={i} hover>
+                    <TableCell>{row.region}</TableCell>
+                    <TableCell>{row.property_type}</TableCell>
+                    <TableCell>{row.year}</TableCell>
+                    <TableCell align="right">
+                      {new Intl.NumberFormat("en-CA", {
+                        style: "currency",
+                        currency: "CAD",
+                        maximumFractionDigits: 0,
+                      }).format(row.price)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      )}
+    </Container>
+  );
+}

--- a/frontend/src/pages/WhereCanLivePage.js
+++ b/frontend/src/pages/WhereCanLivePage.js
@@ -1,0 +1,205 @@
+import React, { useState } from "react";
+import {
+  Container,
+  Typography,
+  Paper,
+  Box,
+  Stack,
+  TextField,
+  FormControl,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Button,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from "@mui/material";
+
+const YEARS = Array.from({ length: 21 }, (_, i) => 2000 + i);
+const PROPERTY_TYPES = ["House", "Condo", "Apartment"];
+const REGIONS = [
+  "Toronto",
+  "Vancouver",
+  "Montreal",
+  "Calgary",
+  "Ottawa",
+  "Halifax",
+];
+
+// Dummy data
+const DUMMY_RESULTS = [
+  { region: "Calgary", hai: 30.53 },
+  { region: "Ottawa", hai: 29.0 },
+  { region: "Montreal", hai: 27.62 },
+  { region: "Vancouver", hai: 26.36 },
+  { region: "Halifax", hai: 25.0 },
+];
+
+export default function WhereCanLivePage() {
+  const [started, setStarted] = useState(false);
+  const [income, setIncome] = useState("");
+  const [year, setYear] = useState("");
+  const [propertyType, setPropertyType] = useState("");
+  const [region, setRegion] = useState("");
+  const [results, setResults] = useState([]);
+
+  const startQuiz = () => {
+    setStarted(true);
+    setResults([]); // clear
+  };
+
+  const handleFind = () => {
+    // Immediately show dummy data:
+    setResults(DUMMY_RESULTS);
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ pt: 4, pb: 4 }}>
+      {/* Header */}
+      <Typography variant="h4" gutterBottom align="left">
+        Find Out Where You Could Have Afforded to Live
+      </Typography>
+      <Typography
+        variant="subtitle1"
+        color="text.secondary"
+        gutterBottom
+        align="left"
+      >
+        Based on your income, family size, and housing preferences, we’ll
+        recommend affordable regions in Canada using historical HAI data.
+      </Typography>
+
+      {/* Start Button */}
+      {!started && (
+        <Box mb={4} sx={{ textAlign: "left" }}>
+          <Button
+            onClick={startQuiz}
+            sx={{
+              background: "linear-gradient(to right, #6a11cb, #2575fc)",
+              color: "white",
+              px: 3,
+              py: 1.5,
+            }}
+          >
+            Start the Quiz
+          </Button>
+        </Box>
+      )}
+
+      {/* Quiz Form */}
+      {started && (
+        <Paper elevation={2} sx={{ p: 4, mb: 4 }}>
+          <Stack spacing={3} alignItems="flex-start">
+            <TextField
+              label="What was your total annual income (in CAD)?"
+              type="number"
+              fullWidth
+              value={income}
+              onChange={(e) => setIncome(e.target.value)}
+            />
+
+            <FormControl component="fieldset">
+              <Typography variant="subtitle2" gutterBottom>
+                Which year are you interested in?
+              </Typography>
+              <RadioGroup
+                row
+                value={year}
+                onChange={(e) => setYear(e.target.value)}
+              >
+                {YEARS.map((y) => (
+                  <FormControlLabel
+                    key={y}
+                    value={String(y)}
+                    control={<Radio />}
+                    label={String(y)}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+
+            <FormControl component="fieldset">
+              <Typography variant="subtitle2" gutterBottom>
+                What kind of housing were you interested in?
+              </Typography>
+              <RadioGroup
+                row
+                value={propertyType}
+                onChange={(e) => setPropertyType(e.target.value)}
+              >
+                {PROPERTY_TYPES.map((pt) => (
+                  <FormControlLabel
+                    key={pt}
+                    value={pt}
+                    control={<Radio />}
+                    label={pt}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+
+            <FormControl component="fieldset">
+              <Typography variant="subtitle2" gutterBottom>
+                Do you have a preferred region?
+              </Typography>
+              <RadioGroup
+                row
+                value={region}
+                onChange={(e) => setRegion(e.target.value)}
+              >
+                {REGIONS.map((r) => (
+                  <FormControlLabel
+                    key={r}
+                    value={r}
+                    control={<Radio />}
+                    label={r}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+
+            <Button
+              onClick={handleFind}
+              sx={{
+                background: "linear-gradient(to right, #6a11cb, #2575fc)",
+                color: "white",
+                px: 3,
+                py: 1.5,
+              }}
+            >
+              Find Affordable Regions
+            </Button>
+          </Stack>
+        </Paper>
+      )}
+
+      {/* Results */}
+      {results.length > 0 && (
+        <Paper elevation={1}>
+          <TableContainer sx={{ maxHeight: 300 }}>
+            <Table stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Region</TableCell>
+                  <TableCell align="right">HAI Score</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {results.map((row, i) => (
+                  <TableRow key={i} hover>
+                    <TableCell>{row.region}</TableCell>
+                    <TableCell align="right">{row.hai.toFixed(2)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      )}
+    </Container>
+  );
+}


### PR DESCRIPTION
This PR adds the first four core features of our “O Canada Homes” application, including fully functional front‐end pages with stubbed data, consistent Material-UI styling, and responsive layouts. It also wires up routing and the navbar.

What’s included:

- Housing & Income Trends pages (/housing, /income) with Province→Region selects, Year/Property‐Type filters, search spinner, and results tables.
- Affordability Quiz (/quiz): single‐page flow—“Start Quiz” intro, income/year/type form, stubbed HAI results.
- Reverse Lookup (/reverse-lookup): target price, margin, optional Year/Type filters, stubbed matches table.
- Affordability Ranking (/ranking): Year & Property‐Type selects, stubbed top‐5 HAI index table.

https://github.com/user-attachments/assets/ee1855bb-1f2d-4b71-9b14-76e261c8ed5e

